### PR TITLE
Add support for Dify context timeout

### DIFF
--- a/linedify/dify.py
+++ b/linedify/dify.py
@@ -127,15 +127,14 @@ class DifyAgent:
 
         raise Exception("Workflow is not supported for now.")
 
-    async def invoke(self, user_id: str, text: str = None, image: bytes = None) -> Tuple[str, Dict]:
+    async def invoke(self, conversation_id: str, text: str = None, image: bytes = None, start_as_new: bool = False) -> Tuple[str, Dict]:
         headers = {
             "Authorization": f"Bearer {self.api_key}"
         }
 
         payloads = await self.make_payloads(text, image)
 
-        conversation_id = self.conversation_ids.get(user_id)
-        if conversation_id:
+        if conversation_id and not start_as_new:
             payloads["conversation_id"] = conversation_id
 
         async with aiohttp.ClientSession() as session:
@@ -155,5 +154,4 @@ class DifyAgent:
                 response_processor = self.response_processors[self.type]
                 conversation_id, response_text, response_data = await response_processor(response)
 
-                self.conversation_ids[user_id] = conversation_id
-                return response_text, response_data
+                return conversation_id, response_text, response_data

--- a/tests/test_dify.py
+++ b/tests/test_dify.py
@@ -51,25 +51,24 @@ async def test_make_payloads_with_image(dify_agent, image_bytes):
 
 @pytest.mark.asyncio
 async def test_invoke(dify_agent):
-    response_text, response_data = await dify_agent.invoke(user_id="test_user_id", text="This is a test. Respond success.")
+    conversation_id, response_text, response_data = await dify_agent.invoke(conversation_id=None, text="This is a test. Respond success.")
 
     assert "success" in response_text.lower()
     assert response_data == {}
-    assert dify_agent.conversation_ids["test_user_id"] is not None
+    assert conversation_id is not None
 
-    conversation_id = dify_agent.conversation_ids["test_user_id"]
-    response_text, response_data = await dify_agent.invoke(user_id="test_user_id", text="This is a test. Respond success again.")
+    conversation_id2, response_text, response_data = await dify_agent.invoke(conversation_id=conversation_id, text="This is a test. Respond success again.")
 
     assert "success" in response_text.lower()
     assert response_data == {}
-    assert dify_agent.conversation_ids["test_user_id"] == conversation_id
+    assert conversation_id2 == conversation_id
 
 
 @pytest.mark.asyncio
 async def test_invoke_with_image(dify_agent, image_bytes):
-    response_text, response_data = await dify_agent.invoke(user_id="test_user_id", text="what's this?", image=image_bytes)
+    conversation_id, response_text, response_data = await dify_agent.invoke(conversation_id=None, text="what's this? Answer in English.", image=image_bytes)
 
     assert "cat" in response_text.lower()
     assert "girl" in response_text.lower()
     assert response_data == {}
-    assert dify_agent.conversation_ids["test_user_id"] is not None
+    assert conversation_id is not None


### PR DESCRIPTION
Previously, conversation_id in Dify tied to LINE user ID was maintained in memory until server restart.
Now, conversation_id times out and a new one is issued after a certain period (default: 1 hour since last conversation).