### PR TITLE
Support inputs as an argument for Dify conversation threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,30 @@ async def process_response(text: str, data: dict) -> List[SendMessage]:
 line_dify.process_response = process_response
 ```
 
+## 🎨 Customize Inputs
+
+You can customize `inputs` as arguments for Dify conversation threads.
+
+```python
+def make_inputs(session: ConversationSession):
+    # You can use session to customize inputs dynamically here
+
+    if not session.conversation_id:
+        return {"foo": "bar"}
+    else:
+        return {}
+
+line_dify = LineDify(
+    line_channel_access_token=YOUR_CHANNEL_ACCESS_TOKEN,
+    line_channel_secret=YOUR_CHANNEL_SECRET,
+    dify_api_key=DIFY_API_KEY,
+    dify_base_url=DIFY_BASE_URL,
+    dify_user=DIFY_USER
+)
+
+line_dify.make_inputs = make_inputs
+```
+
 
 ## 😢 Customize Error Message
 

--- a/linedify/dify.py
+++ b/linedify/dify.py
@@ -31,9 +31,9 @@ class DifyAgent:
         }
         self.conversation_ids = {}
 
-    async def make_payloads(self, text: str, image_bytes: bytes = None) -> Dict:
+    async def make_payloads(self, text: str, image_bytes: bytes = None, inputs: dict = None) -> Dict:
         payloads = {
-            "inputs": {},
+            "inputs": inputs or {},
             "query": text,
             "response_mode": "streaming" if self.type == DifyType.Agent else "blocking",
             "user": self.user,
@@ -127,12 +127,12 @@ class DifyAgent:
 
         raise Exception("Workflow is not supported for now.")
 
-    async def invoke(self, conversation_id: str, text: str = None, image: bytes = None, start_as_new: bool = False) -> Tuple[str, Dict]:
+    async def invoke(self, conversation_id: str, text: str = None, image: bytes = None, inputs: dict = None, start_as_new: bool = False) -> Tuple[str, Dict]:
         headers = {
             "Authorization": f"Bearer {self.api_key}"
         }
 
-        payloads = await self.make_payloads(text, image)
+        payloads = await self.make_payloads(text, image, inputs)
 
         if conversation_id and not start_as_new:
             payloads["conversation_id"] = conversation_id

--- a/linedify/integration.py
+++ b/linedify/integration.py
@@ -63,6 +63,7 @@ class LineDifyIntegrator:
             verbose=self.verbose
         )
 
+        self.make_inputs = None
         self.error_response = error_response
 
     async def process_request(self, request_body: str, signature: str):
@@ -111,7 +112,12 @@ class LineDifyIntegrator:
             request_text, image_bytes = await parse_message(event.message)
 
             conversation_session = await self.conversation_session_store.get_session(event.source.user_id)
-            conversation_id, text, data = await self.dify_agent.invoke(conversation_session.conversation_id, text=request_text, image=image_bytes)
+            if self.make_inputs:
+                inputs = self.make_inputs(conversation_session)
+            else:
+                inputs = {}
+
+            conversation_id, text, data = await self.dify_agent.invoke(conversation_session.conversation_id, text=request_text, image=image_bytes, inputs=inputs)
             conversation_session.conversation_id = conversation_id
             await self.conversation_session_store.set_session(conversation_session)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -70,3 +70,24 @@ async def test_parse_text_message(line_dify):
     parsed_text, parsed_image = await line_dify.parse_location_message(text_message)
     assert parsed_text == f"You received a location info from user in messenger app:\n    - address: Jiyugaoka, Tokyo\n    - latitude: 35.6\n    - longitude: 139.6"
     assert parsed_image is None
+
+
+@pytest.mark.asyncio
+async def test_make_inputs(line_dify):
+    # TODO: Make test for handle_message_event
+
+    def make_inputs(session):
+        if not session.conversation_id:
+            return {"foo": "bar"}
+        else:
+            return {}
+
+    line_dify.make_inputs = make_inputs
+
+    session = await line_dify.conversation_session_store.get_session("user_id")
+    inputs = line_dify.make_inputs(session)
+    assert inputs.get("foo") == "bar"
+
+    session.conversation_id = "1234567890"
+    inputs = line_dify.make_inputs(session)
+    assert inputs.get("foo") is None


### PR DESCRIPTION
Add support for inputs as an argument in Dify conversation threads.

```python
def make_inputs(session: ConversationSession):
    if not session.conversation_id:
        inputs = {"foo": "bar"}
    else:
        inputs = {}

line_dify = LineDifyIntegrator()
line_dify.make_inputs = make_inputs
```