### PR TITLE
Adopt decorators for custom logic registration🍰

### DIFF
--- a/linedify/integration.py
+++ b/linedify/integration.py
@@ -1,7 +1,7 @@
 import json
 from logging import getLogger, NullHandler
 from traceback import format_exc
-from typing import List, Tuple
+from typing import Dict, List, Tuple, Union
 import aiohttp
 from linebot import AsyncLineBotApi, WebhookParser
 from linebot.aiohttp_async_http_client import AiohttpAsyncHttpClient
@@ -11,7 +11,7 @@ from linebot.models import (
     ImageMessage, SendMessage, TextSendMessage
 )
 from .dify import DifyAgent, DifyType
-from .session import ConversationSessionStore
+from .session import ConversationSession, ConversationSessionStore
 
 
 logger = getLogger(__name__)
@@ -26,7 +26,6 @@ class LineDifyIntegrator:
         dify_base_url: str,
         dify_user: str,
         dify_type: DifyType = DifyType.Agent,
-        error_response: str = None,
         session_db_url: str = "sqlite:///sessions.db",
         session_timeout: float = 3600.0,
         verbose: bool = False
@@ -42,7 +41,13 @@ class LineDifyIntegrator:
             async_http_client=client
         )
         self.webhook_parser = WebhookParser(channel_secret=line_channel_secret)
-        self.message_parsers = {
+
+        self._validate_event = self.validate_event_default
+        self._event_handlers = {
+            "message": self.handle_message_event
+        }
+        self._default_event_handler = self.event_handler_default
+        self._message_parsers = {
             "text": self.parse_text_message,
             "image": self.parse_image_message,
             "sticker": self.parse_sticker_message,
@@ -63,26 +68,117 @@ class LineDifyIntegrator:
             verbose=self.verbose
         )
 
-        # Custom logics
-        self.validate_event = None
-        self.make_inputs = None
+        self._make_inputs = self.make_inputs_default
+        self._to_reply_message = self.to_reply_message_default
+        self._to_error_message = self.to_error_message_default
 
-        self.error_response = error_response
+    # Decorators
+    def event(self, event_type=None):
+        def decorator(func):
+            if event_type is None:
+                self._default_event_handler = func
+            else:
+                self._event_handlers[event_type] = func
+            return func
+        return decorator
 
+    def parse_message(self, message_type):
+        def decorator(func):
+            self._message_parsers[message_type] = func
+            return func
+        return decorator
+
+    def validate_event(self, func):
+        self._validate_event = func
+        return func
+
+    def make_inputs(self, func):
+        self._make_inputs = func
+        return func
+
+    def to_reply_message(self, func):
+        self._to_reply_message = func
+        return func
+
+    def to_error_message(self, func):
+        self._to_error_message = func
+        return func
+
+    # Processors
     async def process_request(self, request_body: str, signature: str):
         events = self.webhook_parser.parse(request_body, signature)
         for event in events:
-            await self.process_event(event)
+            reply_messages = await self.process_event(event)
+
+            try:
+                if reply_messages and hasattr(event, "reply_token"):
+                    await self.line_api.reply_message(event.reply_token, reply_messages)
+
+            except Exception as eex:
+                logger.error(f"Error at replying error message for event: {eex}\n{format_exc()}")
 
     async def process_event(self, event: Event):
         try:
-            if event.type == "message":
-                await self.handle_message_event(event)
+            if validation_messages := await self._validate_event(event):
+                return validation_messages
+            
             else:
-                await self.handle_event(event)
+                event_handler = self._event_handlers.get(event.type)
+                if event_handler:
+                    return await event_handler(event)
+                else:
+                    return await self._default_event_handler(event)
+
         except Exception as ex:
             logger.error(f"Error at process_event: {ex}\n{format_exc()}")
+            return await self._to_error_message(event, ex)
 
+    # Event handlers
+    async def handle_message_event(self, event: MessageEvent):
+        conversation_session = None
+        try:
+            if self.verbose:
+                logger.info(f"Request from LINE: {json.dumps(event.as_json_dict(), ensure_ascii=False)}")
+
+            parse_message = self._message_parsers.get(event.message.type)
+            if not parse_message:
+                raise Exception(f"Unhandled message type: {event.message.type}")
+
+            request_text, image_bytes = await parse_message(event.message)
+            conversation_session = await self.conversation_session_store.get_session(event.source.user_id)
+            inputs = await self._make_inputs(conversation_session)
+
+            conversation_id, text, data = await self.dify_agent.invoke(
+                conversation_session.conversation_id,
+                text=request_text,
+                image=image_bytes,
+                inputs=inputs
+            )
+
+            conversation_session.conversation_id = conversation_id
+            await self.conversation_session_store.set_session(conversation_session)
+
+            response_messages = await self._to_reply_message(text, data, conversation_session)
+
+            if self.verbose:
+                logger.info(f"Response to LINE: {', '.join([json.dumps(m.as_json_dict(), ensure_ascii=False) for m in response_messages])}")
+
+            return response_messages
+
+        except Exception as ex:
+            logger.error(f"Error at handle_message_event: {ex}\n{format_exc()}")
+
+            try:
+                error_message = await self._to_error_message(event, ex, conversation_session)
+                return error_message
+
+            except Exception as eex:
+                logger.error(f"Error at replying error message for message event: {eex}\n{format_exc()}")
+
+    async def event_handler_default(self, event: Event):
+        logger.warning(f"Unhandled event type: {event.type}")
+
+    # Message parsers
     async def parse_text_message(self, message: TextMessage) -> Tuple[str, bytes]:
         return message.text, None
 
@@ -100,58 +196,19 @@ class LineDifyIntegrator:
     async def parse_location_message(self, message: LocationMessage) -> Tuple[str, bytes]:
         return f"You received a location info from user in messenger app:\n    - address: {message['address']}\n    - latitude: {message['latitude']}\n    - longitude: {message['longitude']}", None
 
-    async def make_error_response(self, event: MessageEvent, ex: Exception) -> List[SendMessage]:
-        return [TextSendMessage(text=self.error_response or "Error 🥲")]
+    # Defaults
+    async def validate_event_default(self, Event) -> Union[None, List[SendMessage]]:
+        return None
 
-    async def handle_message_event(self, event: MessageEvent):
-        try:
-            if self.verbose:
-                logger.info(f"Request from LINE: {json.dumps(event.as_json_dict(), ensure_ascii=False)}")
+    async def make_inputs_default(self, session: ConversationSession) -> Dict:
+        return {}
 
-            if self.validate_event:
-                validation_message = await self.validate_event(event)
-                if validation_message:
-                    await self.line_api.reply_message(event.reply_token, [validation_message])
-                    return
-
-            parse_message = self.message_parsers.get(event.message.type)
-            if not parse_message:
-                raise Exception(f"Unhandled message type: {event.message.type}")
-
-            request_text, image_bytes = await parse_message(event.message)
-
-            conversation_session = await self.conversation_session_store.get_session(event.source.user_id)
-            if self.make_inputs:
-                inputs = self.make_inputs(conversation_session)
-            else:
-                inputs = {}
-
-            conversation_id, text, data = await self.dify_agent.invoke(conversation_session.conversation_id, text=request_text, image=image_bytes, inputs=inputs)
-            conversation_session.conversation_id = conversation_id
-            await self.conversation_session_store.set_session(conversation_session)
-
-            response_messages = await self.process_response(text, data)
-
-            if self.verbose:
-                logger.info(f"Response to LINE: {', '.join([json.dumps(m.as_json_dict(), ensure_ascii=False) for m in response_messages])}")
-
-            await self.line_api.reply_message(event.reply_token, response_messages)
-
-        except Exception as ex:
-            logger.error(f"Error at handle_message_event: {ex}\n{format_exc()}")
-
-            try:
-                error_response = await self.make_error_response(event, ex)
-                await self.line_api.reply_message(event.reply_token, error_response)
-
-            except Exception as eex:
-                logger.error(f"Error at replying error message: {eex}\n{format_exc()}")
-
-    async def handle_event(self, event: Event):
-        logger.warning(f"Unhandled event type: {event.type}")
-
-    async def process_response(self, text: str, data: dict) -> List[SendMessage]:
+    async def to_reply_message_default(self, text: str, data: dict, session: ConversationSession) -> List[SendMessage]:
         return [TextSendMessage(text=text)]
 
+    async def to_error_message_default(self, event: Event, ex: Exception, session: ConversationSession = None) -> List[SendMessage]:
+        return [TextSendMessage(text="Error 🥲")]
+
+    # Application lifecycle
     async def shutdown(self):
         await self.line_api_session.close()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 import pytest
+import json
 import os
-from linebot.models import TextMessage, ImageMessage, StickerMessage, LocationMessage
+from linebot.models import MessageEvent, PostbackEvent, FollowEvent, ImageMessage, StickerMessage, LocationMessage, TextSendMessage
 from linedify import LineDify, DifyType
 
 
@@ -40,12 +41,88 @@ def image_bytes():
         return image_file.read()
 
 
+def to_message_event(text: str) -> MessageEvent:
+    json_dict = json.loads('{"deliveryContext": {"isRedelivery": false}, "message": {"id": "521033363122028567", "text": "", "type": "text"}, "mode": "active", "replyToken": "7d34442b4f0c4f319f721ed6293fb70f", "source": {"type": "user", "userId": "U1234xx5f678x90x123456x78x9012xx3"}, "timestamp": 1723391389452, "type": "message", "webhookEventId": "01J5123C4954D0284W9KN11QCX"}')
+    json_dict["message"]["text"] = text
+    return MessageEvent.new_from_json_dict(json_dict)
+
+
+def to_location_message_event() -> MessageEvent:
+    json_dict = json.loads('{"deliveryContext": {"isRedelivery": false}, "message": {"address": "\u6771\u4eac\u90fd\u76ee\u9ed2\u533a\u81ea\u7531\u304c\u4e181\u4e01\u76ee9-8", "id": "521035897605456135", "latitude": 35.6075767, "longitude": 139.6690939, "title": "\u81ea\u7531\u304c\u4e18\u99c5\uff08\u6771\u6025\uff09", "type": "location"}, "mode": "active", "replyToken": "10047dd69f4b483f97c4d3aa13f0ce70", "source": {"type": "user", "userId": "U1234xx5f678x90x123456x78x9012xx3"}, "timestamp": 1723392900114, "type": "message", "webhookEventId": "01J513HFD69N3SD0SRAD16CZ8S"}')
+    return MessageEvent.new_from_json_dict(json_dict)
+
+
+def to_image_message_event() -> MessageEvent:
+    json_dict = json.loads('{"deliveryContext": {"isRedelivery": false}, "message": {"address": "\u6771\u4eac\u90fd\u76ee\u9ed2\u533a\u81ea\u7531\u304c\u4e181\u4e01\u76ee9-8", "id": "521035897605456135", "latitude": 35.6075767, "longitude": 139.6690939, "title": "\u81ea\u7531\u304c\u4e18\u99c5\uff08\u6771\u6025\uff09", "type": "location"}, "mode": "active", "replyToken": "10047dd69f4b483f97c4d3aa13f0ce70", "source": {"type": "user", "userId": "U1234xx5f678x90x123456x78x9012xx3"}, "timestamp": 1723392900114, "type": "message", "webhookEventId": "01J513HFD69N3SD0SRAD16CZ8S"}')
+    return MessageEvent.new_from_json_dict(json_dict)
+
+
+def to_postback_event(data: str) -> PostbackEvent:
+    json_dict = json.loads('{"replyToken": "b60d432864f44d079f6d8efe86cf404b","type": "postback","mode": "active","source": {"userId": "U91eeaf62d...","type": "user"},"timestamp": 1513669370317,"webhookEventId": "01FZ74A0TDDPYRVKNK77XKC3ZR","deliveryContext": {"isRedelivery": false},"postback": {"data": "","params": {"datetime": "2017-12-25T01:00"}}}')
+    json_dict["postback"]["data"] = data
+    return PostbackEvent.new_from_json_dict(json_dict)
+
+
+def to_follow_event() -> FollowEvent:
+    json_dict = json.loads('{"replyToken": "85cbe770fa8b4f45bbe077b1d4be4a36","type": "follow","mode": "active","timestamp": 1705891467176,"source": {"type": "user","userId": "U3d3edab4f36c6292e6d8a8131f141b8b"},"webhookEventId": "01HMQGW40RZJPJM3RAJP7BHC2Q","deliveryContext": {"isRedelivery": false},"follow": {"isUnblocked": false}}')
+    return FollowEvent.new_from_json_dict(json_dict)
+
+
 @pytest.mark.asyncio
-async def test_parse_text_message(line_dify):
-    text_message = TextMessage(text="Hello, world!")
-    parsed_text, parsed_image = await line_dify.parse_text_message(text_message)
-    assert parsed_text == "Hello, world!"
-    assert parsed_image is None
+async def test_validate_event(line_dify):
+    @line_dify.validate_event
+    async def validate_event(event):
+        if hasattr(event, "reply_token"):
+            if event.type == "message" and event.message.type == "text" and event.message.text == "invalid":
+                return [TextSendMessage("invalid event")]
+
+    reply_messages = await line_dify.process_event(to_message_event("hello"))
+    assert reply_messages[0].text is not None
+    assert reply_messages[0].text != ""
+    assert reply_messages[0].text != "invalid event"
+
+    reply_messages = await line_dify.process_event(to_message_event("invalid"))
+    assert reply_messages[0].text == "invalid event"
+
+
+@pytest.mark.asyncio
+async def test_handle_events(line_dify):
+    @line_dify.event("postback")
+    async def handle_message_event(event):
+        return [TextSendMessage(f"Response for postback event: {event.postback.data}")]
+
+    @line_dify.event()
+    async def handle_event(event):
+        return [TextSendMessage(f"Response for event type: {event.type}")]
+
+    # Default message event handler works
+    reply_messages = await line_dify.process_event(to_message_event("say hello"))
+    assert "hello" in reply_messages[0].text.lower()
+
+    # Postback
+    reply_messages = await line_dify.process_event(to_postback_event("foo=bar"))
+    assert "foo=bar" in reply_messages[0].text
+
+    # Follow
+    reply_messages = await line_dify.process_event(to_follow_event())
+    assert reply_messages[0].text == "Response for event type: follow"
+
+
+@pytest.mark.asyncio
+async def test_parse_messages(line_dify):
+    @line_dify.parse_message("text")
+    async def parse_text_message(message):
+        return (f"「{message.text}」の対義語を答えてください", None)
+
+    @line_dify.parse_message("location")
+    async def parse_location_message(message):
+        return (f"「{message.title}」は何区ですか？", None)
+
+    reply_messages = await line_dify.process_event(to_message_event("明るい"))
+    assert "暗い" in reply_messages[0].text
+
+    reply_messages = await line_dify.process_event(to_location_message_event())
+    assert "目黒" in reply_messages[0].text
 
 
 @pytest.mark.asyncio
@@ -74,20 +151,38 @@ async def test_parse_text_message(line_dify):
 
 @pytest.mark.asyncio
 async def test_make_inputs(line_dify):
-    # TODO: Make test for handle_message_event
+    @line_dify.make_inputs
+    async def make_inputs(session):
+        return {"favorite_food": "りんご"}
 
-    def make_inputs(session):
-        if not session.conversation_id:
-            return {"foo": "bar"}
-        else:
-            return {}
+    await line_dify.conversation_session_store.expire_session("U1234xx5f678x90x123456x78x9012xx3")
+    reply_messages = await line_dify.process_event(to_message_event("ユーザーの好きな食べ物は？"))
+    assert "りんご" in reply_messages[0].text
 
-    line_dify.make_inputs = make_inputs
 
-    session = await line_dify.conversation_session_store.get_session("user_id")
-    inputs = line_dify.make_inputs(session)
-    assert inputs.get("foo") == "bar"
+@pytest.mark.asyncio
+async def test_to_reply_message(line_dify):
+    @line_dify.to_reply_message
+    async def to_reply_message(text, data, session):
+        reply_messages = await line_dify.to_reply_message_default(text, data, session)
+        reply_messages.append(TextSendMessage("Additional message"))
+        return reply_messages
 
-    session.conversation_id = "1234567890"
-    inputs = line_dify.make_inputs(session)
-    assert inputs.get("foo") is None
+    reply_messages = await line_dify.process_event(to_message_event("say hello"))
+    assert "hello" in reply_messages[0].text.lower()
+    assert reply_messages[1].text == "Additional message"
+
+
+@pytest.mark.asyncio
+async def test_to_error_message(line_dify):
+    @line_dify.to_error_message
+    async def to_error_message(event, ex, session = None):
+        text = "Custom error message"
+        return [TextSendMessage(text=text)]
+
+    @line_dify.event("message")
+    async def handle_message_event(event):
+        raise
+
+    reply_messages = await line_dify.process_event(to_message_event("hello"))
+    assert reply_messages[0].text == "Custom error message"


### PR DESCRIPTION
Switched from direct assignment of user-defined functions (e.g., line_dify.make_inputs = make_inputs) to using decorators for registering custom logic.

This change allows users to register their custom functions more intuitively by simply using @line_dify.make_inputs above the function definition, enhancing code clarity and maintainability.