### PR TITLE
Add feature for formatting request text to Dify

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,20 @@ async def parse_location_message(message):
 ```
 
 
+### Format Request
+
+Use `@line_dify.format_request_text` to format request. (e.g. apply the template)
+
+```python
+@line_dify.format_request_text
+async def format_request_text(request_text, image_bytes):
+    return f"""The user's input is as follows. Think before providing a response:
+
+{request_text}
+"""
+```
+
+
 ### Inputs
 
 Use `@line_dify.make_inputs` to customize `inputs` as arguments for Dify conversation threads.

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="linedify",
-    version="0.3.2",
+    version="0.3.3",
     url="https://github.com/uezo/linedify",
     author="uezo",
     author_email="uezo@uezo.net",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -153,6 +153,16 @@ async def test_parse_location_message(line_dify):
 
 
 @pytest.mark.asyncio
+async def test_format_request_text(line_dify):
+    @line_dify.format_request_text
+    async def format_request_text(request_text, image_bytes):
+        return "「ニャー」と言ってください。それ以外絶対に何も言わないこと"
+
+    reply_messages = await line_dify.process_event(to_message_event("ユーザーの好きな食べ物は？"))
+    assert "ニャー" in reply_messages[0].text
+
+
+@pytest.mark.asyncio
 async def test_make_inputs(line_dify):
     @line_dify.make_inputs
     async def make_inputs(session):


### PR DESCRIPTION
Use `@line_dify.format_request_text` to format request. (e.g. apply the template)

```python
@line_dify.format_request_text
async def format_request_text(request_text, image_bytes):
    return f"""The user's input is as follows. Think before providing a response:

{request_text}
"""
```